### PR TITLE
Add file 'number' to dialog titles

### DIFF
--- a/src/step01.rb
+++ b/src/step01.rb
@@ -11,7 +11,7 @@ module Step01
     <p><button onclick="sketchup.poke('Thom', 3)">Poke</button></p>
 EOT
     options = {
-      :dialog_title => "Material",
+      :dialog_title => "01 Material",
       :preferences_key => "example.htmldialog.materialinspector",
       :style => UI::HtmlDialog::STYLE_DIALOG  # New feature!
     }

--- a/src/step02.rb
+++ b/src/step02.rb
@@ -15,7 +15,7 @@ module Step02
     <p><button onclick="sketchup.poke('Thom', 3)">Poke</button></p>
 EOT
     options = {
-      :dialog_title => "Material",
+      :dialog_title => "02 Material",
       :preferences_key => "example.htmldialog.materialinspector",
       :style => UI::HtmlDialog::STYLE_DIALOG
     }

--- a/src/step03.rb
+++ b/src/step03.rb
@@ -6,7 +6,7 @@ module Step03
 
   def self.create_dialog
     options = {
-      :dialog_title => "Material",
+      :dialog_title => "03 Material",
       :preferences_key => "example.htmldialog.materialinspector",
       :style => UI::HtmlDialog::STYLE_DIALOG
     }

--- a/src/step04.rb
+++ b/src/step04.rb
@@ -8,7 +8,7 @@ module Step04
   def self.create_dialog
     html_file = File.join(__dir__, 'html', 'step04.html') # Use external HTML
     options = {
-      :dialog_title => "Material",
+      :dialog_title => "04 Material",
       :preferences_key => "example.htmldialog.materialinspector",
       :style => UI::HtmlDialog::STYLE_DIALOG
     }

--- a/src/step05.rb
+++ b/src/step05.rb
@@ -11,7 +11,7 @@ module Step05
   def self.create_dialog
     html_file = File.join(__dir__, 'html', 'step05.html')
     options = {
-      :dialog_title => "Material",
+      :dialog_title => "05 Material",
       :preferences_key => "example.htmldialog.materialinspector",
       :style => UI::HtmlDialog::STYLE_DIALOG
     }

--- a/src/step06.rb
+++ b/src/step06.rb
@@ -10,7 +10,7 @@ module Step06
   def self.create_dialog
     html_file = File.join(__dir__, 'html', 'step06.html')
     options = {
-      :dialog_title => "Material",
+      :dialog_title => "06 Material",
       :preferences_key => "example.htmldialog.materialinspector",
       :style => UI::HtmlDialog::STYLE_DIALOG
     }

--- a/src/step07.rb
+++ b/src/step07.rb
@@ -18,7 +18,7 @@ module Step07
       height += 40
     end
     options = {
-      :dialog_title => "Material",
+      :dialog_title => "07 Material",
       :preferences_key => "com.sketchup.example.htmldialog.materialinspector",
       :style => UI::HtmlDialog::STYLE_DIALOG,
       # Set a fixed size now that we know the content size.


### PR DESCRIPTION
One could parse the filename to get the number, but the number is also hard-coded in the html file, etc...